### PR TITLE
Актуализация урлов API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/334c15601db179ab0562/maintainability)](https://codeclimate.com/github/Sunsetboy/pravoved-api/maintainability)
 
-Неофициальная библиотека для работы с API сервиса pravoved.ru. 
+Неофициальная библиотека для работы с API сервиса myleads.feedot.com. 
 
 Внимание: автор никак не связан с компанией Правовед. Библиотека была создана для интеграции моего проекта с сервисом и поставляется "Как есть".
+
+Документация по API: https://myleads.feedot.com/api-doc/
 
 ### Возможности:
 * Получение авторизационного токена

--- a/src/PravovedApiClient.php
+++ b/src/PravovedApiClient.php
@@ -33,7 +33,7 @@ class PravovedApiClient
      * @param string $apiUrl URL API Правоведа
      * @param string|null $authToken Токен, если известен
      */
-    public function __construct($authToken = null, $apiUrl = 'https://pravoved.ru/restv2')
+    public function __construct($authToken = null, $apiUrl = 'https://api.myleads.feedot.com/restv2')
     {
         $this->apiUrl = $apiUrl;
 


### PR DESCRIPTION
Лиды (новый бренд - Федот, https://feedot.com) отсоединились от Правоведа.

Изменил URL запросов в связи с этим и добавил ссылку на документацию.